### PR TITLE
Suggested Bicep edits

### DIFF
--- a/aks.bicep
+++ b/aks.bicep
@@ -1,31 +1,42 @@
 // mandatory params
+@description('The unique DNS prefix for your cluster, such as myakscluster. This cannot be updated once the Managed Cluster has been created.')
 param dnsPrefix string
+
+@description('The administrator username to use for Linux VMs.')
 param linuxAdminUsername string
+
+@description('Certificate public key used to authenticate with VMs through SSH. The certificate must be in PEM format with or without headers.')
 param sshRSAPublicKey string
+
+@description('The ID for the service principal.')
 param servicePrincipalClientId string
 
+@description('The unique name for the AKS cluster, such as myAKSCluster.')
 param uniqueclustername string
 
 @secure()
+@description('The secret password associated with the service principal.')
 param servicePrincipalClientSecret string
 
-// optional params
-param clusterName string = uniqueclustername
+// Optional params
+@description('The region to deploy the cluster. By default this will use the same region as the resource group.')
 param location string = resourceGroup().location
 
 @minValue(0)
 @maxValue(1023)
+@description('OS Disk Size in GB to be used to specify the disk size for every machine in the master/agent pool. If you specify 0, it will apply the default osDisk size according to the vmSize specified.')
 param osDiskSizeGB int = 0
 
 @minValue(1)
 @maxValue(50)
+@description('Number of agents (VMs) to host docker containers. Allowed values must be in the range of 0 to 1000 (inclusive) for user pools and in the range of 1 to 1000 (inclusive) for system pools. The default value is 1.')
 param agentCount int = 3
 
+@description('VM size availability varies by region. If a node contains insufficient compute resources (memory, cpu, etc) pods might fail to run correctly. For more details on restricted VM sizes, see: https://docs.microsoft.com/azure/aks/quotas-skus-regions')
 param agentVMSize string = 'Standard_DS2_v2'
-// osType was a defaultValue with only one allowedValue, which seems strange?, could be a good TTK test
 
-resource aks 'Microsoft.ContainerService/managedClusters@2020-09-01' = {
-  name: clusterName
+resource aks 'Microsoft.ContainerService/managedClusters@2021-07-01' = {
+  name: uniqueclustername
   location: location
   properties: {
     dnsPrefix: dnsPrefix


### PR DESCRIPTION
- Use latest managedClusters api version (2021-07-01)
- Remove defaults from required params (setting defaults makes them optional), remove dupe clusterName param
- Add description decorators for all params (quick starts requirement)
- Remove comment "// osType was a defaultValue with only one allowedValue, which seems strange?, could be a good TTK test". osType has 2 allowed values: linux and windows: 
![image](https://user-images.githubusercontent.com/6855361/136052664-76702115-380e-4f44-ba1a-1cf0af6a4a5a.png)

Additional suggestion: Use getSecret() function for all secret params https://docs.microsoft.com/en-us/azure/azure-resource-manager/bicep/key-vault-parameter?tabs=azure-cli